### PR TITLE
Fixed parent controls for <Knob/>

### DIFF
--- a/src/components/synth-panel/Synthy.tsx
+++ b/src/components/synth-panel/Synthy.tsx
@@ -102,23 +102,6 @@ const Synthy = ({ presets = basePresets }: Props) => {
 		level: 0.5,
 	});
 
-	const handleMasterVol = (_: string, value: number) => {
-		const level = value / 100;
-		setMasterVolume(level);
-	};
-
-	// supports: octave, key, scale
-	const handleSetting = (name: string, value: string) => {
-		setSynthSettings({
-			...synthSettings,
-			[name]: value,
-		});
-	};
-
-	const handlePreset = (preset: string) => {
-		setSelectedPreset(preset);
-	};
-
 	const handleVCO = (name: string, value: string | number) => {
 		setVCOSettings({
 			...vcoSettings,
@@ -148,6 +131,23 @@ const Synthy = ({ presets = basePresets }: Props) => {
 			...delaySettings,
 			[name]: value,
 		});
+	};
+
+	const handleMasterVol = (_: string, value: number) => {
+		const level = value / 100;
+		setMasterVolume(level);
+	};
+
+	// supports: octave, key, scale
+	const handleSetting = (name: string, value: string) => {
+		setSynthSettings({
+			...synthSettings,
+			[name]: value,
+		});
+	};
+
+	const handlePreset = (preset: string) => {
+		setSelectedPreset(preset);
 	};
 
 	// note handlers (TEMPORARY???)

--- a/src/components/synth-panel/SynthyEffects.tsx
+++ b/src/components/synth-panel/SynthyEffects.tsx
@@ -77,11 +77,13 @@ const reverbOptions: IDropdownOption[] = [
 ];
 
 const SynthyEffects = ({
-	// vcoVals,
-	// adsrVals,
-	// delayVals,
-	// reverbVals,
-	// filterVals,
+	// grouped states
+	vcoVals,
+	adsrVals,
+	delayVals,
+	reverbVals,
+	filterVals,
+	// handlers
 	handleVCO,
 	handleADSR,
 	handleFilter,
@@ -98,7 +100,7 @@ const SynthyEffects = ({
 					size="SM"
 					name="waveType"
 					label="Waveform"
-					// val={vcoVals.waveType}
+					value={vcoVals.waveType}
 					onChange={handleVCO} // string
 				/>
 				<Knob
@@ -106,7 +108,7 @@ const SynthyEffects = ({
 					key="Gain"
 					name="gain"
 					size={size}
-					// val={vcoVals?.gain}
+					value={vcoVals?.gain}
 					onChange={handleVCO} // number
 				/>
 			</EffectColumn>
@@ -117,7 +119,7 @@ const SynthyEffects = ({
 					key="Attack"
 					name="attack"
 					size={size}
-					// val={adsrVals?.attack}
+					value={adsrVals?.attack}
 					onChange={handleADSR}
 				/>
 				<Knob
@@ -125,7 +127,7 @@ const SynthyEffects = ({
 					key="Decay"
 					name="decay"
 					size={size}
-					// val={adsrVals?.decay}
+					value={adsrVals?.decay}
 					onChange={handleADSR}
 				/>
 				<Knob
@@ -133,7 +135,7 @@ const SynthyEffects = ({
 					key="Sustain"
 					name="sustain"
 					size={size}
-					// val={adsrVals?.sustain}
+					value={adsrVals?.sustain}
 					onChange={handleADSR}
 				/>
 				<Knob
@@ -141,7 +143,7 @@ const SynthyEffects = ({
 					key="Release"
 					name="release"
 					size={size}
-					// val={adsrVals?.release}
+					value={adsrVals?.release}
 					onChange={handleADSR}
 				/>
 			</EffectBlock>
@@ -159,6 +161,7 @@ const SynthyEffects = ({
 					label="Freq."
 					name="freq"
 					size={size}
+					value={filterVals?.freq}
 					onChange={handleFilter}
 				/>
 				<Knob
@@ -166,6 +169,7 @@ const SynthyEffects = ({
 					label="Semi."
 					name="semitones"
 					size={size}
+					value={filterVals?.semitones}
 					onChange={handleFilter}
 				/>
 				<Knob
@@ -173,6 +177,7 @@ const SynthyEffects = ({
 					key="Level"
 					name="level"
 					size={size}
+					value={filterVals?.level}
 					onChange={handleFilter}
 				/>
 			</EffectBlock>
@@ -184,6 +189,7 @@ const SynthyEffects = ({
 					label="Time."
 					name="time"
 					size={size}
+					value={delayVals?.time}
 					onChange={handleDelay}
 				/>
 				<Knob
@@ -191,6 +197,7 @@ const SynthyEffects = ({
 					label="Feedback"
 					name="feedback"
 					size={size}
+					value={delayVals?.feedback}
 					onChange={handleDelay}
 				/>
 				<Knob
@@ -198,6 +205,7 @@ const SynthyEffects = ({
 					key="Level"
 					name="level"
 					size={size}
+					value={delayVals?.level}
 					onChange={handleDelay}
 				/>
 			</EffectBlock>
@@ -217,6 +225,7 @@ const SynthyEffects = ({
 					label="Time."
 					name="time"
 					size={size}
+					value={reverbVals?.time}
 					onChange={handleReverb}
 				/>
 				<Knob
@@ -224,6 +233,7 @@ const SynthyEffects = ({
 					label="Feedback"
 					name="feedback"
 					size={size}
+					value={reverbVals?.feedback}
 					onChange={handleReverb}
 				/>
 				<Knob
@@ -231,6 +241,7 @@ const SynthyEffects = ({
 					key="Level"
 					name="level"
 					size={size}
+					value={reverbVals?.level}
 					onChange={handleReverb}
 				/>
 			</EffectBlock>

--- a/src/components/synth/WaveformKnob.tsx
+++ b/src/components/synth/WaveformKnob.tsx
@@ -11,6 +11,7 @@ type Props = {
 	label: string;
 	name?: string;
 	size?: KnobSize;
+	value: string;
 	onChange: (name: string, type: string) => void;
 };
 
@@ -34,13 +35,14 @@ const options: IOption[] = [
 	},
 ];
 
-const WaveformKnob = ({ label, name, onChange, size = "SM" }: Props) => {
+const WaveformKnob = ({ label, value, name, onChange, size = "SM" }: Props) => {
 	return (
 		<div className={styles.WaveformKnob}>
 			<KnotchedKnob
 				size={size}
 				name={name}
 				label={label}
+				// value={value}
 				options={options}
 				onChange={onChange}
 			/>

--- a/src/pages/SynthyPage.tsx
+++ b/src/pages/SynthyPage.tsx
@@ -1,13 +1,35 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "../css/pages/SynthyPage.module.scss";
 import Synthy from "../components/synth-panel/Synthy";
+import Knob from "../components/controls/Knob";
 
 type Props = {};
 
 const SynthyPage = ({}: Props) => {
+	const [knobValue, setKnobValue] = useState<number>(0.38);
+
+	const updateValue = (newVal: number) => {
+		const value = newVal / 100;
+		setKnobValue(value);
+	};
+
+	const handleChange = (_: string, value: number) => {
+		updateValue(value);
+	};
+
 	return (
 		<div className={styles.SynthyPage}>
 			<h1>Synthy Polyphonic Synth</h1>
+			<main className={styles.SynthyPage_main}>
+				<Knob
+					key="test1"
+					name="test1"
+					label="Test"
+					// defaultVal={knobValue}
+					value={Math.round(knobValue * 100)}
+					onChange={handleChange}
+				/>
+			</main>
 			<main className={styles.SynthyPage_main}>
 				<Synthy />
 			</main>


### PR DESCRIPTION
Updated the `<Knob/>` UI control to support default values & setting the `value` field from the parent, in order to support presets w/ value sets mapped to them.