### PR TITLE
Fix UI knobs to support range handling internally. Update arc styles for variants.

### DIFF
--- a/src/components/controls/Knob.tsx
+++ b/src/components/controls/Knob.tsx
@@ -255,7 +255,7 @@ const Knob = ({
 			onMouseLeave={debounce(hideValue, 50)}
 		>
 			<div className={styles.Knob_wrapper} style={knobCss}>
-				{enableArc && <KnobArc value={value} />}
+				{enableArc && <KnobArc value={value} size={size} />}
 				<KnobDial knobRef={knobRef} onMouseDown={mouseDown} size={size} />
 			</div>
 			{!isDragging && !shouldShowValue && <Label label={label} />}

--- a/src/components/controls/Knob.tsx
+++ b/src/components/controls/Knob.tsx
@@ -1,6 +1,13 @@
-import { useRef, useState, useEffect, RefObject, CSSProperties } from "react";
+import {
+	useRef,
+	useState,
+	useEffect,
+	RefObject,
+	CSSProperties,
+	useMemo,
+} from "react";
 import styles from "../../css/controls/Knob.module.scss";
-import { clamp, debounce } from "../../utils/utils_shared";
+import { CRange, clamp, debounce, isBetween } from "../../utils/utils_shared";
 import KnobArc from "./KnobArc";
 
 type Props = {
@@ -161,6 +168,19 @@ const getDefaultValue = (defaultVal: number = 0, range: KnobRange) => {
 	return degs;
 };
 
+const getNormalizedValue = (value: number): number => {
+	// has to be 1 instead of 0 since decimals would give false positive for our purposes
+	const MIN = 1;
+	const MAX = 100;
+	const numIsInRange = isBetween(value, { min: MIN, max: MAX });
+	if (numIsInRange) {
+		return value;
+	} else {
+		const rangeValue = value * MAX;
+		return rangeValue;
+	}
+};
+
 let lastY: number = 0;
 
 const Knob = ({
@@ -169,16 +189,19 @@ const Knob = ({
 	name = "knob",
 	size = "SM",
 	label = "Level",
-	value = 0,
+	value = 0, // can be anything, but MUST be normalized to be: 0-100
 	onChange,
 	enableArc = false,
 }: Props) => {
 	const knobRef = useRef<HTMLDivElement>(null);
+	const cleanValue: number = useMemo(() => {
+		const norm = getNormalizedValue(value);
+		return norm;
+	}, [value]);
 	const [isDragging, setIsDragging] = useState<boolean>(false);
 	const [angle, setAngle] = useState<number>(
 		getDefaultValue(value, { min, max })
 	);
-	// value used for actual controls (eg. 0-100)
 	// shows value on hover
 	const [shouldShowValue, setShouldShowValue] = useState<boolean>(false);
 	const knobCss: CSSProperties = getSize(size);
@@ -255,11 +278,11 @@ const Knob = ({
 			onMouseLeave={debounce(hideValue, 50)}
 		>
 			<div className={styles.Knob_wrapper} style={knobCss}>
-				{enableArc && <KnobArc value={value} size={size} />}
+				{enableArc && <KnobArc value={cleanValue} size={size} />}
 				<KnobDial knobRef={knobRef} onMouseDown={mouseDown} size={size} />
 			</div>
 			{!isDragging && !shouldShowValue && <Label label={label} />}
-			{(shouldShowValue || isDragging) && <LabelValue value={value} />}
+			{(shouldShowValue || isDragging) && <LabelValue value={cleanValue} />}
 		</div>
 	);
 };

--- a/src/components/controls/KnobArc.tsx
+++ b/src/components/controls/KnobArc.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import { CSSProperties, useMemo, useRef } from "react";
 import styles from "../../css/controls/KnobArc.module.scss";
+import { clamp } from "../../utils/utils_shared";
 
 type Props = {
 	value: number;
@@ -10,11 +11,28 @@ type Props = {
 
 type ArcSize = "XSM" | "SM" | "MD" | "LG" | "XLG";
 
+const getArcPosition = (size: ArcSize): CSSProperties => {
+	const sizes = {
+		XSM: 31, // top: 31%
+		SM: 32.885, // top: 34%
+		MD: 34, // top: 34%
+		LG: 34,
+		XLG: 34,
+	};
+	const position = {
+		top: sizes?.[size as keyof object] + "%",
+	};
+
+	return position;
+};
+
 const getArcSize = (size: ArcSize): number => {
 	const sizes = {
-		XSM: 50,
-		SM: 75,
-		MD: 150,
+		XSM: 54, // top: 31%
+		SM: 67.5, // top: 34%
+		// SM: 70, // top: 34%
+		// MD: 85, // top: 34%
+		MD: 82, // top: 34%
 		LG: 175,
 		XLG: 200,
 	};
@@ -22,15 +40,66 @@ const getArcSize = (size: ArcSize): number => {
 	return sizes?.[size as keyof object];
 };
 
+const getStrokeFromSize = (size: ArcSize): number => {
+	const sizes = {
+		XSM: 0.4,
+		SM: 0.5,
+		MD: 0.5,
+		LG: 0.6,
+		XLG: 0.7,
+	};
+	return sizes?.[size as keyof object];
+};
+
+// Should be in range of: 0-100
+// Note: the svg arc has a range of 0-19, so we use 0-20 as our range & apply an OFFSET=1
+const getArcValue = (value: number) => {
+	const OFFSET = 1;
+	const arc = value * 20;
+	const arcValue = arc / 100 - OFFSET;
+	const clamped = clamp(arcValue, { min: 0, max: 20 });
+
+	return clamped;
+};
+
+const getNormValue = (value: number) => {
+	if (value <= 1) {
+		return value * 100;
+	} else if (value > 1 && value <= 100) {
+		return value;
+	} else {
+		return value;
+	}
+};
+
 const KnobArc = ({
 	value,
 	size = "SM",
-	bg = "grey",
-	color = "slateblue",
+	bg = "rgb(32, 34, 35)",
+	color = "var(--accent-bright-red)",
 }: Props) => {
-	const arcSize = getArcSize(size);
+	const arcRef = useRef<SVGPathElement>(null);
+	const normedValue = useMemo(() => {
+		const newVal = getNormValue(value);
+		return newVal;
+	}, [value]);
+	const arcSize = getArcSize(size); // px
+	const arcValue = getArcValue(normedValue); // 0-20
+	const strokeWidth = getStrokeFromSize(size); // px
+	const arcPosition = getArcPosition(size);
+
+	console.log("arcValue", arcValue);
+
+	const updateArc = (value: number) => {
+		const arcEl = arcRef?.current as SVGPathElement;
+		const normedValue = getNormValue(value);
+		const dasharray = `${normedValue} 100 100`;
+
+		arcEl.setAttribute("stroke-dasharray", dasharray);
+	};
+
 	return (
-		<div className={styles.KnobArc}>
+		<div className={styles.KnobArc} style={arcPosition}>
 			<svg
 				id="svgArc"
 				viewBox="0 0 10 10"
@@ -43,19 +112,20 @@ const KnobArc = ({
 					className={styles.KnobArc_outer}
 					d="M2 8 A 4 4 0 1 1 8 8"
 					fill="none"
-					strokeWidth=".7"
+					strokeWidth={strokeWidth}
 					stroke={bg}
 					strokeLinecap="round"
 				/>
 				<path
 					id="progress"
+					ref={arcRef}
 					className={styles.KnobArc_progress}
 					d="M2 8 A 4 4 0 1 1 8 8"
 					fill="none"
-					strokeWidth=".7"
+					strokeWidth={strokeWidth}
 					stroke={color}
 					strokeLinecap="round"
-					strokeDasharray={`${value} 100 100`}
+					strokeDasharray={`${arcValue} 100 100`}
 				/>
 			</svg>
 		</div>

--- a/src/components/controls/KnobArc.tsx
+++ b/src/components/controls/KnobArc.tsx
@@ -10,14 +10,14 @@ type Props = {
 };
 
 type ArcSize = "XSM" | "SM" | "MD" | "LG" | "XLG";
-
+// arc's position relative to knob
 const getArcPosition = (size: ArcSize): CSSProperties => {
 	const sizes = {
-		XSM: 31, // top: 31%
-		SM: 32.885, // top: 34%
-		MD: 34, // top: 34%
-		LG: 34,
-		XLG: 34,
+		XSM: 31,
+		SM: 32.885,
+		MD: 34,
+		LG: 36,
+		XLG: 38,
 	};
 	const position = {
 		top: sizes?.[size as keyof object] + "%",
@@ -25,21 +25,19 @@ const getArcPosition = (size: ArcSize): CSSProperties => {
 
 	return position;
 };
-
+// Diameter of arc around inner knob's circle
 const getArcSize = (size: ArcSize): number => {
 	const sizes = {
-		XSM: 54, // top: 31%
-		SM: 67.5, // top: 34%
-		// SM: 70, // top: 34%
-		// MD: 85, // top: 34%
-		MD: 82, // top: 34%
-		LG: 175,
-		XLG: 200,
+		XSM: 54,
+		SM: 67.5,
+		MD: 82,
+		LG: 112,
+		XLG: 140,
 	};
 
 	return sizes?.[size as keyof object];
 };
-
+// Stroke width
 const getStrokeFromSize = (size: ArcSize): number => {
 	const sizes = {
 		XSM: 0.4,
@@ -53,7 +51,7 @@ const getStrokeFromSize = (size: ArcSize): number => {
 
 // Should be in range of: 0-100
 // Note: the svg arc has a range of 0-19, so we use 0-20 as our range & apply an OFFSET=1
-const getArcValue = (value: number) => {
+const getArcValue = (value: number): number => {
 	const OFFSET = 1;
 	const arc = value * 20;
 	const arcValue = arc / 100 - OFFSET;
@@ -62,13 +60,16 @@ const getArcValue = (value: number) => {
 	return clamped;
 };
 
-const getNormValue = (value: number) => {
-	if (value <= 1) {
-		return value * 100;
-	} else if (value > 1 && value <= 100) {
+// Checks whether our 'value' is in the 0-100 range & if not will normalize it to be in range
+const getNormValue = (value: number): number => {
+	const MIN = 1;
+	const MAX = 100;
+	const MULTIPLIER = 100;
+
+	if (value > MIN && value <= MAX) {
 		return value;
 	} else {
-		return value;
+		return value * MULTIPLIER;
 	}
 };
 
@@ -88,8 +89,7 @@ const KnobArc = ({
 	const strokeWidth = getStrokeFromSize(size); // px
 	const arcPosition = getArcPosition(size);
 
-	console.log("arcValue", arcValue);
-
+	// prolly not needed
 	const updateArc = (value: number) => {
 		const arcEl = arcRef?.current as SVGPathElement;
 		const normedValue = getNormValue(value);

--- a/src/components/controls/MasterVolume.tsx
+++ b/src/components/controls/MasterVolume.tsx
@@ -2,10 +2,11 @@ import styles from "../../css/controls/MasterVolume.module.scss";
 import Knob from "./Knob";
 
 type Props = {
+	value: number;
 	handleMasterVol: (name: string, vol: number) => void;
 };
 
-const MasterVolume = ({ handleMasterVol }: Props) => {
+const MasterVolume = ({ value, handleMasterVol }: Props) => {
 	return (
 		<fieldset className={styles.MasterVolume}>
 			<legend>Master</legend>
@@ -15,7 +16,9 @@ const MasterVolume = ({ handleMasterVol }: Props) => {
 					label="Volume"
 					name="masterVolume"
 					size="MD"
+					value={value}
 					onChange={handleMasterVol}
+					enableArc
 				/>
 			</div>
 		</fieldset>

--- a/src/components/synth-panel/Synthy.tsx
+++ b/src/components/synth-panel/Synthy.tsx
@@ -109,33 +109,43 @@ const Synthy = ({ presets = basePresets }: Props) => {
 	});
 
 	const handleVCO = (name: string, value: string | number) => {
+		// we need to normalize/translate numeric values back to decimals
+		const normVal = typeof value === "number" ? value / 100 : value;
 		setVCOSettings({
 			...vcoSettings,
-			[name]: value,
+			[name]: normVal,
 		});
 	};
 	const handleADSR = (name: string, value: string | number) => {
+		// we need to normalize/translate numeric values back to decimals
+		const normVal = typeof value === "number" ? value / 100 : value;
 		setADSRSettings({
 			...adsrSettings,
-			[name]: value,
+			[name]: normVal,
 		});
 	};
 	const handleFilter = (name: string, value: string | number) => {
+		// we need to normalize/translate numeric values back to decimals
+		const normVal = typeof value === "number" ? value / 100 : value;
 		setFilterSettings({
 			...filterSettings,
-			[name]: value,
+			[name]: normVal,
 		});
 	};
 	const handleReverb = (name: string, value: string | number) => {
+		// we need to normalize/translate numeric values back to decimals
+		const normVal = typeof value === "number" ? value / 100 : value;
 		setReverbSettings({
 			...reverbSettings,
-			[name]: value,
+			[name]: normVal,
 		});
 	};
 	const handleDelay = (name: string, value: string | number) => {
+		// we need to normalize/translate numeric values back to decimals
+		const normVal = typeof value === "number" ? value / 100 : value;
 		setDelaySettings({
 			...delaySettings,
-			[name]: value,
+			[name]: normVal,
 		});
 	};
 

--- a/src/components/synth-panel/Synthy.tsx
+++ b/src/components/synth-panel/Synthy.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import styles from "../../css/synth-panel/Synthy.module.scss";
 import SynthyEffects from "./SynthyEffects";
 import SynthyTopPanel from "./SynthyTopPanel";
@@ -16,8 +16,10 @@ import {
 	ReverbSettings,
 	VCOSettings,
 } from "./types";
+import { createStreamNode } from "../../utils/utils_audio";
 
 const basePresets = [
+	"--INIT--",
 	"Dark Pad",
 	"Echo Moog",
 	"Gliding Swell",
@@ -44,7 +46,7 @@ interface ISynthySettings {
 }
 
 type Props = {
-	presets: string[];
+	presets?: string[];
 };
 
 // REQUIREMENTS:
@@ -54,6 +56,8 @@ type Props = {
 // 		- Load different notes map???
 // 		- Re-render keyboard keys w/ new notes map assigned???
 
+let audioCtx: AudioContext;
+
 const Synthy = ({ presets = basePresets }: Props) => {
 	const recorder = useAudioRecorder({
 		audioType: "audio/ogg; codec=opus",
@@ -61,18 +65,20 @@ const Synthy = ({ presets = basePresets }: Props) => {
 			console.log("audioBlob", audioBlob);
 		},
 	});
+	const audioDestNode = useRef<MediaStreamAudioDestinationNode>();
 	const [isPlaying, setIsPlaying] = useState<boolean>(false);
 	// top panel settings
 	const [selectedPreset, setSelectedPreset] = useState<string>(
 		presets[defaultIdx]
 	);
+	const [masterVolume, setMasterVolume] = useState<number>(0.5);
 	// Eg. key: (C), octave: 0-10, scale: 'Minor'
 	const [synthSettings, setSynthSettings] = useState<ISynthySettings>({
 		octave: octaves[defaultIdx],
 		key: keys[defaultIdx],
 		scale: scales[defaultIdx],
 	});
-	const [masterVolume, setMasterVolume] = useState<number>(0.5);
+
 	// VCO settings
 	const [vcoSettings, setVCOSettings] = useState<VCOSettings>({
 		waveType: "triangle",
@@ -91,13 +97,13 @@ const Synthy = ({ presets = basePresets }: Props) => {
 		level: 0.5,
 	});
 	const [reverbSettings, setReverbSettings] = useState<ReverbSettings>({
-		reverbWave: "",
-		time: 300, // ms
+		reverbWave: "Echo",
+		time: 0.5, // ms (eg .5 => 500ms)
 		feedback: 0.5,
 		level: 0.5,
 	});
 	const [delaySettings, setDelaySettings] = useState<DelaySettings>({
-		time: 300, // ms
+		time: 0.5, // ms (eg .5 => 500ms)
 		feedback: 0.5,
 		level: 0.5,
 	});
@@ -150,7 +156,7 @@ const Synthy = ({ presets = basePresets }: Props) => {
 		setSelectedPreset(preset);
 	};
 
-	// note handlers (TEMPORARY???)
+	// note handlers
 	const handlePress = (note: INote) => {
 		// do stuff
 	};
@@ -165,13 +171,31 @@ const Synthy = ({ presets = basePresets }: Props) => {
 		// do stuff
 	};
 
-	const startTimer = () => {
-		//
-		//
+	// initialize recorder & stream node for oscillators
+	const initRecorder = () => {
+		const destNode = createStreamNode(
+			audioCtx
+		) as MediaStreamAudioDestinationNode;
+
+		// store in our ref(s)
+		audioDestNode.current = destNode;
+
+		// // Connect the osc to the destNode: oscNode.connect(destNode)
+		recorder.initRecorder({
+			audioCtx: audioCtx,
+			mediaStream: destNode.stream,
+			startRecording: false,
+		});
 	};
-	const stopTimer = () => {
-		//
-		//
+
+	const startRecording = () => {
+		if (!audioCtx || !audioDestNode?.current) {
+			initRecorder();
+		}
+		recorder.start();
+	};
+	const stopRecording = () => {
+		recorder.stop();
 	};
 
 	return (
@@ -188,6 +212,9 @@ const Synthy = ({ presets = basePresets }: Props) => {
 				vcoVals={vcoSettings}
 				adsrVals={adsrSettings}
 				filterVals={filterSettings}
+				delayVals={delaySettings}
+				reverbVals={reverbSettings}
+				masterVolume={masterVolume}
 				// effect handlers
 				handleVCO={handleVCO}
 				handleADSR={handleADSR}
@@ -196,7 +223,7 @@ const Synthy = ({ presets = basePresets }: Props) => {
 				handleReverb={handleReverb}
 				handleMasterVol={handleMasterVol}
 			/>
-			<SynthyRecordingPanel start={startTimer} stop={stopTimer} />
+			<SynthyRecordingPanel start={startRecording} stop={stopRecording} />
 			<SynthyKeysPanel>
 				{allNotes &&
 					allNotes.map((note, idx) => (

--- a/src/components/synth-panel/SynthyEffects.tsx
+++ b/src/components/synth-panel/SynthyEffects.tsx
@@ -27,6 +27,7 @@ type Props = {
 	filterVals: FilterSettings;
 	delayVals: DelaySettings;
 	reverbVals: ReverbSettings;
+	masterVolume: number;
 	handleDelay: (name: string, value: number) => void;
 	handleVCO: (name: string, value: string | number) => void;
 	handleADSR: (name: string, value: string | number) => void;
@@ -83,6 +84,7 @@ const SynthyEffects = ({
 	delayVals,
 	reverbVals,
 	filterVals,
+	masterVolume,
 	// handlers
 	handleVCO,
 	handleADSR,
@@ -246,7 +248,7 @@ const SynthyEffects = ({
 				/>
 			</EffectBlock>
 			{/* MASTER VOLUME */}
-			<MasterVolume handleMasterVol={handleMasterVol} />
+			<MasterVolume value={masterVolume} handleMasterVol={handleMasterVol} />
 		</div>
 	);
 };

--- a/src/css/controls/KnobArc.module.scss
+++ b/src/css/controls/KnobArc.module.scss
@@ -6,8 +6,12 @@
 	width: auto;
 	height: auto;
 	position: absolute;
-	top: 30%;
+	// top: 32%;
+	top: 31%;
 	left: 50%;
-	// background-color: var(--border);
 	transform: translate(-50%, -50%);
+
+	& > svg > path {
+		transition: stroke-dasharray 0.1s ease-in-out;
+	}
 }

--- a/src/css/controls/KnobArc.module.scss
+++ b/src/css/controls/KnobArc.module.scss
@@ -6,8 +6,7 @@
 	width: auto;
 	height: auto;
 	position: absolute;
-	// top: 32%;
-	top: 31%;
+	top: 32%;
 	left: 50%;
 	transform: translate(-50%, -50%);
 

--- a/src/css/pages/SynthyPage.module.scss
+++ b/src/css/pages/SynthyPage.module.scss
@@ -5,6 +5,14 @@
 .SynthyPage {
 	@include fill_container;
 
+	&_demo {
+		width: 100%;
+		@include flex_row(center, flex-start);
+		padding: 4rem 2rem;
+		margin-bottom: 4rem;
+		background-color: #eaecef;
+	}
+
 	&_main {
 		@include fill_container;
 		padding: 6rem 4rem;

--- a/src/pages/SynthyPage.tsx
+++ b/src/pages/SynthyPage.tsx
@@ -18,7 +18,7 @@ const SynthyPage = () => {
 				<Knob
 					name="test1"
 					label="Test"
-					size="SM"
+					size="XLG"
 					value={Math.round(value * 100)}
 					onChange={handleVal}
 					enableArc={true}

--- a/src/pages/SynthyPage.tsx
+++ b/src/pages/SynthyPage.tsx
@@ -1,35 +1,30 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import styles from "../css/pages/SynthyPage.module.scss";
 import Synthy from "../components/synth-panel/Synthy";
 import Knob from "../components/controls/Knob";
 
-type Props = {};
+const SynthyPage = () => {
+	const [value, setValue] = useState<number>(0.5);
 
-const SynthyPage = ({}: Props) => {
-	const [knobValue, setKnobValue] = useState<number>(0.38);
-
-	const updateValue = (newVal: number) => {
-		const value = newVal / 100;
-		setKnobValue(value);
+	const handleVal = (_: string, newVal: number) => {
+		const formatted = newVal / 100;
+		setValue(formatted);
 	};
-
-	const handleChange = (_: string, value: number) => {
-		updateValue(value);
-	};
-
 	return (
 		<div className={styles.SynthyPage}>
 			<h1>Synthy Polyphonic Synth</h1>
-			<main className={styles.SynthyPage_main}>
+
+			<div className={styles.SynthyPage_demo}>
 				<Knob
-					key="test1"
 					name="test1"
 					label="Test"
-					// defaultVal={knobValue}
-					value={Math.round(knobValue * 100)}
-					onChange={handleChange}
+					size="SM"
+					value={Math.round(value * 100)}
+					onChange={handleVal}
+					enableArc={true}
 				/>
-			</main>
+			</div>
+
 			<main className={styles.SynthyPage_main}>
 				<Synthy />
 			</main>

--- a/src/utils/utils_shared.ts
+++ b/src/utils/utils_shared.ts
@@ -57,6 +57,14 @@ const clamp = (val: number, range: CRange) => {
 	return clampedValue;
 };
 
+// Checks if a number is between a given range
+const isBetween = (value: number, range: CRange): boolean => {
+	const { min, max } = range;
+	const isInRange = value >= min && value <= max;
+
+	return isInRange;
+};
+
 // Uses for..loop instead of Array.prototype.reduce
 const groupBy = <T, K extends string | number>(
 	key: K,
@@ -98,6 +106,7 @@ export {
 	range,
 	clamp,
 	groupBy,
+	isBetween,
 	getRandomNumInRange,
 	generateRandomList,
 	// Performance Utils


### PR DESCRIPTION
For the `<Knob />` and `<KnobArc />` components we need to support various values & ranges of values, but the components themselves MUST have a static & normalized range of values, so I updated the components to control range/value translations & conversions locally. This change prevents having to update numerous different locations of code & it insures that variable ranges can be used with the component(s) without issues or having to re-implement translations/conversions for every use. It removes the coupling between the parent (consumer) & child (utility)

- Updated `<Knob/>` component to convert values to use a `0-100` range for easier conversions & tracking of values
- Updated `<KnobArc/>` to support translations similar to the knob component
- Added better styling & formatting of the `<KnobArc/>` for the `size` variant values (eg. `XSM`, `SM`, `MD`, `LG`, `XLG`).
- Updated `<Knob/>` event handlers in `<Synthy/>` component to accomodate translations, when needed
  - This is so I can maintain the relevant values used in the `AudioNode`s, but still use the correct format in the consumer components.